### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
             run:
                 working-directory: ./app
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
             - name: Install Zig toolchain


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v4` → `actions/checkout@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI maintenance change that only updates the GitHub Actions `checkout` step; potential impact is limited to the build pipeline if the new action version behaves differently.
> 
> **Overview**
> Updates the Rust GitHub Actions workflow to use `actions/checkout@v6` instead of `@v4`, aligning CI with newer (Node.js 24–compatible) action versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 310860524e5e5392cac8e7b79d5fc82817dd63c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->